### PR TITLE
Change URL for python-fmask

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -5,7 +5,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://bitbucket.org/chchrsc/python-fmask/downloads/python-fmask-{{ version }}.tar.gz
+  url: https://github.com/ubarsc/python-fmask/releases/download/pythonfmask-{{ version }}/python-fmask-{{ version }}.tar.gz
   sha256: ed20776f6b63615f664da89a9e3951c79437b66c2bf88fe19a93c2cc7dc40c82
 
 build:


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Ensured the license file is being packaged.

`python-fmask` has moved to github. This PR simply updates the URL so rebuilds in the future will work. 

ping @neilflood